### PR TITLE
Prevent get_md5_ctx from returning NULL pointers

### DIFF
--- a/MD5.xs
+++ b/MD5.xs
@@ -463,6 +463,7 @@ static MD5_CTX* get_md5_ctx(pTHX_ SV* sv)
 	}
     }
 
+    croak("Failed to get MD5_CTX pointer");
     return (MD5_CTX*)0; /* some compilers insist on a return value */
 }
 

--- a/t/files.t
+++ b/t/files.t
@@ -14,14 +14,14 @@ my $EXPECT;
 if (ord "A" == 193) { # EBCDIC
     $EXPECT = <<EOT;
 4f932585bed0cc942186fb51daff4839  README
-193abcfb4767f4473509b21a9b42776b  MD5.xs
+56a026df94b92f79fec0257cef713eeb  MD5.xs
 276da0aa4e9a08b7fe09430c9c5690aa  rfc1321.txt
 EOT
 } else {
     # This is the output of: 'md5sum README MD5.xs rfc1321.txt'
     $EXPECT = <<EOT;
 c8d3f8457a2d6983253d771ffddb9f4c  README
-c14d082938335107aa429c3d351f178a  MD5.xs
+a534eb04dfbf36aa54634d05ff108b42  MD5.xs
 754b9db19f79dbc4992f7166eb0f37ce  rfc1321.txt
 EOT
 }


### PR DESCRIPTION
This fixes a minor regression I introduced while making the module threadsafe.
