### PR TITLE
Add ->context() feature to Digest::MD5.

### DIFF
--- a/MD5.pm
+++ b/MD5.pm
@@ -227,6 +227,16 @@ The base64 encoded string returned is not padded to be a multiple of 4
 bytes long.  If you want interoperability with other base64 encoded
 md5 digests you might want to append the string "==" to the result.
 
+=item @ctx = $md5->context
+
+=item $md5->context(@ctx)
+
+Saves or restores the internal state.  When called with no arguments,
+returns a 3-element list: number of blocks processed, a 16-byte
+internal state buffer, then up to 63 bytes of unprocessed data.  When
+passed those same arguments, restores the state.  This is only useful
+for specialised operations.
+
 =back
 
 

--- a/MD5.xs
+++ b/MD5.xs
@@ -731,6 +731,45 @@ digest(context)
         XSRETURN(1);
 
 void
+context(ctx, ...)
+	MD5_CTX* ctx
+    PREINIT:
+	char out[16];
+        U32 w;
+    PPCODE:
+	if (items > 2) {
+	    STRLEN len;
+	    unsigned long blocks = SvUV(ST(1));
+	    unsigned char *buf = (unsigned char *)(SvPV(ST(2), len));
+	    ctx->A = buf[ 0] | (buf[ 1]<<8) | (buf[ 2]<<16) | (buf[ 3]<<24);
+	    ctx->B = buf[ 4] | (buf[ 5]<<8) | (buf[ 6]<<16) | (buf[ 7]<<24);
+	    ctx->C = buf[ 8] | (buf[ 9]<<8) | (buf[10]<<16) | (buf[11]<<24);
+	    ctx->D = buf[12] | (buf[13]<<8) | (buf[14]<<16) | (buf[15]<<24);
+	    ctx->bytes_low = blocks << 6;
+	    ctx->bytes_high = blocks >> 26;
+	    if (items == 4) {
+		buf = (unsigned char *)(SvPV(ST(3), len));
+		MD5Update(ctx, buf, len);
+	    }
+	    XSRETURN(1); /* ctx */
+	} else if (items != 1) {
+	    XSRETURN(0);
+	}
+
+        w=ctx->A; out[ 0]=w; out[ 1]=(w>>8); out[ 2]=(w>>16); out[ 3]=(w>>24);
+        w=ctx->B; out[ 4]=w; out[ 5]=(w>>8); out[ 6]=(w>>16); out[ 7]=(w>>24);
+        w=ctx->C; out[ 8]=w; out[ 9]=(w>>8); out[10]=(w>>16); out[11]=(w>>24);
+        w=ctx->D; out[12]=w; out[13]=(w>>8); out[14]=(w>>16); out[15]=(w>>24);
+
+	EXTEND(SP, 3);
+	ST(0) = sv_2mortal(newSVuv(ctx->bytes_high << 26 |
+				   ctx->bytes_low >> 6));
+	ST(1) = sv_2mortal(newSVpv(out, 16));
+	ST(2) = sv_2mortal(newSVpv((char *)ctx->buffer,
+				   ctx->bytes_low & 0x3F));
+	XSRETURN(3);
+
+void
 md5(...)
     ALIAS:
 	Digest::MD5::md5        = F_BIN

--- a/t/files.t
+++ b/t/files.t
@@ -14,14 +14,14 @@ my $EXPECT;
 if (ord "A" == 193) { # EBCDIC
     $EXPECT = <<EOT;
 0956ffb4f6416082b27d6680b4cf73fc  README
-b349234bb1005785bb6e377990209dc7  MD5.xs
+1d52c61cff1f4c493b7db6b65bb68163  MD5.xs
 276da0aa4e9a08b7fe09430c9c5690aa  rfc1321.txt
 EOT
 } else {
     # This is the output of: 'md5sum README MD5.xs rfc1321.txt'
     $EXPECT = <<EOT;
 2f93400875dbb56f36691d5f69f3eba5  README
-f908acbcf6bd32042f282b0deed61264  MD5.xs
+bd80adbca5c4d6f0f33f6b8d70adbe09  MD5.xs
 754b9db19f79dbc4992f7166eb0f37ce  rfc1321.txt
 EOT
 }


### PR DESCRIPTION
The internal state of an md5 object that is not yet finalized is needed
in order to implement Dovecot CRAM-MD5 password hashes.