### PR TITLE
const the vtable

### DIFF
--- a/t/files.t
+++ b/t/files.t
@@ -14,14 +14,14 @@ my $EXPECT;
 if (ord "A" == 193) { # EBCDIC
     $EXPECT = <<EOT;
 0956ffb4f6416082b27d6680b4cf73fc  README
-b349234bb1005785bb6e377990209dc7  MD5.xs
+3af7e3fc84395bce470040413c85af07  MD5.xs
 276da0aa4e9a08b7fe09430c9c5690aa  rfc1321.txt
 EOT
 } else {
     # This is the output of: 'md5sum README MD5.xs rfc1321.txt'
     $EXPECT = <<EOT;
 2f93400875dbb56f36691d5f69f3eba5  README
-f908acbcf6bd32042f282b0deed61264  MD5.xs
+fa89ddf70e7ed55d5e3b7e5d63025173  MD5.xs
 754b9db19f79dbc4992f7166eb0f37ce  rfc1321.txt
 EOT
 }


### PR DESCRIPTION
This makes Digest-MD5 free of any perl caused RW static global data. On
some OSes/CCs this can lead to remove of the RW static global section
from the shared library.