### PR TITLE
Make use warnings work for when XS code warns

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,40 @@
+sudo: required
+dist: trusty
+language: cpp
+compiler:
+- gcc
+before_install:
+# for gcc with C++11 support
+- sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+- sudo apt-get -qq update
+install:
+# install GTest and GMock
+- sudo apt-get -qq install libgtest-dev
+- "cd /usr/src/gtest && sudo cmake . && sudo cmake --build . && sudo mv libg* /usr/local/lib/ ; cd -"
+- sudo apt-get -qq install google-mock
+- "cd /usr/src/gmock && sudo cmake . && sudo cmake --build . && sudo mv libg* /usr/local/lib/ ; cd -"
+# update to gcc with C++11 support
+- sudo apt-get -qq install gcc-4.9 g++-4.9
+- sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 90
+- sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-4.9 90
+- sudo apt-get -qq install libtest-simple-perl
+- sudo apt-get -qq install libtest-harness-perl
+- sudo apt-get -qq install libdigest-perl
+# install latest LCOV (1.9 was failing)
+- cd ${TRAVIS_BUILD_DIR}
+- wget http://ftp.de.debian.org/debian/pool/main/l/lcov/lcov_1.11.orig.tar.gz
+- tar xf lcov_1.11.orig.tar.gz
+- sudo make -C lcov-1.11/ install
+- gem install coveralls-lcov
+- lcov --version
+- g++ --version
+before_script:
+- cd ${TRAVIS_BUILD_DIR}
+# init coverage to 0 (optional)
+- lcov --directory . --zerocounters
+script:
+- cd ${TRAVIS_BUILD_DIR}
+# Check that this works this way
+- perl Makefile.PL
+- make
+- make test

--- a/MD5.xs
+++ b/MD5.xs
@@ -788,7 +788,7 @@ md5(...)
     PPCODE:
 	MD5Init(&ctx);
 
-	if (PL_dowarn & G_WARN_ON) {
+	if ((PL_dowarn & G_WARN_ON) || ckWARN(WARN_SYNTAX)) {
             const char *msg = 0;
 	    if (items == 1) {
 		if (SvROK(ST(0))) {

--- a/t/files.t
+++ b/t/files.t
@@ -14,14 +14,14 @@ my $EXPECT;
 if (ord "A" == 193) { # EBCDIC
     $EXPECT = <<EOT;
 0956ffb4f6416082b27d6680b4cf73fc  README
-2a61dd5022b11faa35eed27d1c6c98c2  MD5.xs
+12f1f02de834904563077137a366eede  MD5.xs
 276da0aa4e9a08b7fe09430c9c5690aa  rfc1321.txt
 EOT
 } else {
     # This is the output of: 'md5sum README MD5.xs rfc1321.txt'
     $EXPECT = <<EOT;
 2f93400875dbb56f36691d5f69f3eba5  README
-0a0cf2512d18d24c6881d7d755e2b609  MD5.xs
+6cb2fa5934f0ecd995f20ef89b9e05e2  MD5.xs
 754b9db19f79dbc4992f7166eb0f37ce  rfc1321.txt
 EOT
 }

--- a/t/warns.t
+++ b/t/warns.t
@@ -1,0 +1,62 @@
+use Digest::MD5;
+use Test::More tests => 6;
+
+$^W = 0; # No warnings
+my $stdr = "";
+{
+  local *STDERR;
+  open STDERR, '>', \$stdr;
+  $str = Digest::MD5->md5_hex("foo");
+  is($stdr,'','No warnings');
+}
+
+$stdr = "";
+{
+  $^W = 1; # magic turn on warnings
+  local *STDERR;
+  open STDERR, '>', \$stdr;
+  $str = Digest::MD5->md5_hex("foo");
+  like($stdr,qr/Digest::MD5::md5_hex function probably called as class method/,
+        'Lexical warning passed to XSUB');
+}
+
+$stdr = "";
+{
+  $^W = 0; # No warnings
+  local *STDERR;
+  open STDERR, '>', \$stdr;
+  $str = Digest::MD5->md5_hex("foo");
+  is($stdr,'','No warnings again');
+}
+
+$stdr = "";
+{
+  use warnings;
+  local *STDERR;
+  open STDERR, '>', \$stdr;
+  $str = Digest::MD5->md5_hex("foo");
+  like($stdr,qr/Digest::MD5::md5_hex function probably called as class method/,
+        'use warnings passed to XSUB');
+}
+
+$stdr = "";
+{
+  use strict;
+  $^W = 0; # No warnings
+  local *STDERR;
+  open STDERR, '>', \$stdr;
+  my $str = Digest::MD5->md5_hex("foo");
+  is($stdr,'','No warnings and strict');
+}
+
+$stdr = "";
+{
+  use strict;
+  use warnings;
+  local *STDERR;
+  open STDERR, '>', \$stdr;
+  my $str = Digest::MD5->md5_hex("foo");
+  like($stdr,qr/Digest::MD5::md5_hex function probably called as class method/,
+        'use warnings passed to XSUB while use strict');
+}
+


### PR DESCRIPTION
I have fixed RT bug 40693 so that warning can be propagated from the XS code up to the Perl level. I have also included related tests. 