### PR TITLE
Fix alignment probe for 64bit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ install:
 - sudo apt-get -qq install libtest-simple-perl
 - sudo apt-get -qq install libtest-harness-perl
 - sudo apt-get -qq install libdigest-perl
+- sudo apt-get -qq install libdb-dev
 # install latest LCOV (1.9 was failing)
 - cd ${TRAVIS_BUILD_DIR}
 - wget http://ftp.de.debian.org/debian/pool/main/l/lcov/lcov_1.11.orig.tar.gz

--- a/MD5.pm
+++ b/MD5.pm
@@ -3,7 +3,9 @@ package Digest::MD5;
 use strict;
 use vars qw($VERSION @ISA @EXPORT_OK);
 
-$VERSION = '2.55';
+$VERSION = '2.55_01';
+my $XS_VERSION = $VERSION;
+$VERSION = eval $VERSION;
 
 require Exporter;
 *import = \&Exporter::import;
@@ -21,7 +23,7 @@ if ($@) {
 
 eval {
     require XSLoader;
-    XSLoader::load('Digest::MD5', $VERSION);
+    XSLoader::load('Digest::MD5', $XS_VERSION);
 };
 if ($@) {
     my $olderr = $@;

--- a/MD5.xs
+++ b/MD5.xs
@@ -830,3 +830,21 @@ md5(...)
 	MD5Final(digeststr, &ctx);
         ST(0) = make_mortal_sv(aTHX_ digeststr, ix);
         XSRETURN(1);
+
+BOOT:
+#if defined(U32_ALIGNMENT_REQUIRED) && defined(__GNUC__) && (defined(__x86_64__) || defined(__i386))
+        /* Generate SIGBUS on unaligned access even on x86:
+           Set AC in EFLAGS. See http://orchistro.tistory.com/206
+           Also see https://sourceforge.net/p/predef/wiki/Architectures/
+           for possible other compilers. Here only GNU C: gcc, clang, icc.
+           MSVC would be nice also. */
+#ifdef __x86_64__
+        __asm__("pushf\n"
+                "orl $0x40000, (%rsp)\n"
+                "popf");
+#else
+        __asm__("pushf\n"
+                "orl $0x40000, (%esp)\n"
+                "popf");
+#endif
+#endif

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,7 +5,8 @@ use Config qw(%Config);
 use ExtUtils::MakeMaker;
 
 my @extra;
-push(@extra, DEFINE => "-DU32_ALIGNMENT_REQUIRED") unless free_u32_alignment();
+# perl5 core cannot be trusted with U32_ALIGNMENT_REQUIRED
+push(@extra, DEFINE => (free_u32_alignment() ? "-U" : "-D")."U32_ALIGNMENT_REQUIRED");
 push(@extra, INSTALLDIRS => 'perl') if $] >= 5.008 && $] < 5.012;
 
 if ($^O eq 'VMS') {
@@ -43,12 +44,18 @@ sub free_u32_alignment
 {
     $|=1;
     if (exists $Config{d_u32align}) {
-       print "Perl's config says that U32 access must ";
-       print "not " unless $Config{d_u32align};
-       print "be aligned.\n";
-       return !$Config{d_u32align};
+        # perl core probe fixed only with cperl5.22.2
+        if ($Config{usecperl} and $] >= 5.022002) {
+            print "Perl's config says that U32 access must ";
+            print "not " unless $Config{d_u32align};
+            print "be aligned.\n";
+            return !$Config{d_u32align};
+        } else {
+            print "Skipping broken perl d_u32align config: $Config{d_u32align}\n";
+        }
     }
-    
+
+    # TODO: only true on intel, not arm/sparc/mips/ppc architectures
     if ($^O eq 'VMS' || $^O eq 'MSWin32') {
        print "Assumes that $^O implies free alignment for U32 access.\n";
        return 1;
@@ -66,7 +73,10 @@ sub free_u32_alignment
 /*  This program allocates a buffer of U8 (char) and then tries */
 /*  to access it through a U32 pointer at every offset.  The    */
 /*  program  is expected to die with a bus error/seg fault for  */
-/*  machines that do not support unaligned integer read/write   */
+/*  machines that do not support unaligned integer read/write.   */
+/*  Note that on Intel it is dependend on the value of the AC bit */
+/*  (alignment check) in EFLAGS. Default off. Even if off, the code */
+/*  for unaligned access is slower. See http://orchistro.tistory.com/206 */
 /*--------------------------------------------------------------*/
 
 #include <stdio.h>
@@ -79,13 +89,13 @@ sub free_u32_alignment
 
 int main(int argc, char** argv, char** env)
 {
-#if BYTEORDER == 0x1234 || BYTEORDER == 0x4321
+#if BYTEORDER == 0x1234 || BYTEORDER == 0x4321 || BYTEORDER == 0x87654321 || BYTEORDER == 0x12345678 || BYTEORDER == 0xFFFF
     volatile U8 buf[] = "\0\0\0\1\0\0\0\0";
     volatile U32 *up;
     int i;
 
     if (sizeof(U32) != 4) {
-	printf("sizeof(U32) is not 4, but %d\n", sizeof(U32));
+	printf("sizeof(U32) is not 4, but %d\n", (int)sizeof(U32));
 	exit(1);
     }
 
@@ -126,10 +136,12 @@ EOT
 
     my $cc_cmd = "$Config{cc} $Config{ccflags} -I$Config{archlibexp}/CORE";
     my $exe = "u32align$Config{exe_ext}";
-    $cc_cmd .= " -o $exe";
-    my $rc;
-    $rc = system("$cc_cmd $Config{ldflags} u32align.c $Config{libs}");
+    $cc_cmd .= " -o $exe $Config{ldflags} u32align.c $Config{libs}";
+    # memory_wrap in croak requires -lperl
+    $cc_cmd .= " -L$Config{archlibexp}/CORE -lperl" if $] > 5.019;
+    my  $rc = system($cc_cmd);
     if ($rc) {
+        print "$cc_cmd\n";
 	print "Can't compile test program.  Will ensure alignment to play safe.\n\n";
 	unlink("u32align.c", $exe, "u32align$Config{obj_ext}");
 	return 0;

--- a/t/files.t
+++ b/t/files.t
@@ -14,14 +14,14 @@ my $EXPECT;
 if (ord "A" == 193) { # EBCDIC
     $EXPECT = <<EOT;
 0956ffb4f6416082b27d6680b4cf73fc  README
-60a80f534f0017745eb755f36a946fe7  MD5.xs
+903cb60d7e2c2df48cd999a78b1dbf3d  MD5.xs
 276da0aa4e9a08b7fe09430c9c5690aa  rfc1321.txt
 EOT
 } else {
     # This is the output of: 'md5sum README MD5.xs rfc1321.txt'
     $EXPECT = <<EOT;
 2f93400875dbb56f36691d5f69f3eba5  README
-9572832f3628e3bebcdd54f47c43dc5a  MD5.xs
+64973c4dd2192cfddd1cd9f449967ed6  MD5.xs
 754b9db19f79dbc4992f7166eb0f37ce  rfc1321.txt
 EOT
 }


### PR DESCRIPTION
and enforce a SIGBUS on intel also (at least with
gnu c compatible compilers: gcc, clang, icc) to
mimic errors on other strict platforms: sparc, mips, ppc

Fixes RT #77919
