### PR TITLE
Stop using use vars

### DIFF
--- a/MD5.pm
+++ b/MD5.pm
@@ -1,13 +1,12 @@
 package Digest::MD5;
 
 use strict;
-use vars qw($VERSION @ISA @EXPORT_OK);
 
 use Exporter qw(import);
 
-$VERSION = '2.55';
-
-@EXPORT_OK = qw(md5 md5_hex md5_base64);
+our $VERSION = '2.55';
+our @EXPORT_OK = qw(md5 md5_hex md5_base64);
+our @ISA;
 
 eval {
     require Digest::base;

--- a/MD5.pm
+++ b/MD5.pm
@@ -3,10 +3,10 @@ package Digest::MD5;
 use strict;
 use vars qw($VERSION @ISA @EXPORT_OK);
 
+use Exporter qw(import);
+
 $VERSION = '2.55';
 
-require Exporter;
-*import = \&Exporter::import;
 @EXPORT_OK = qw(md5 md5_hex md5_base64);
 
 eval {


### PR DESCRIPTION
This series switches the code away from use vars to modern alternatives, including importing Exporter's import via use.
